### PR TITLE
Add React dashboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# React Dashboard
+
+This repository contains a simple React + TypeScript project that renders a dashboard with real-time statistics. The dashboard connects to a small WebSocket server which continuously broadcasts random data.
+
+## Getting started
+
+1. Install dependencies (requires Node.js installed locally):
+
+```bash
+npm install
+```
+
+2. Start the WebSocket server:
+
+```bash
+npm run server
+```
+
+3. In another terminal, start the development server:
+
+```bash
+npm run dev
+```
+
+Navigate to `http://localhost:5173` (default Vite port) to see the dashboard updating in real time.
+
+The WebSocket server runs on `ws://localhost:3001` and sends a new random value every second.

--- a/Readme
+++ b/Readme
@@ -1,1 +1,0 @@
-inital commit

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Real-Time Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "server": "ts-node server/index.ts"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.4",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "ts-node": "^10.9.1",
+    "ws": "^8.13.0"
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,24 @@
+import { WebSocketServer } from 'ws';
+import http from 'http';
+
+const server = http.createServer();
+const wss = new WebSocketServer({ server });
+
+function broadcastStats() {
+  const stats = {
+    timestamp: Date.now(),
+    value: Math.random() * 100,
+  };
+  const message = JSON.stringify(stats);
+  wss.clients.forEach((client) => {
+    if (client.readyState === client.OPEN) {
+      client.send(message);
+    }
+  });
+}
+
+setInterval(broadcastStats, 1000);
+
+server.listen(3001, () => {
+  console.log('WebSocket server running on port 3001');
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Dashboard from './Dashboard';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Real-Time Dashboard</h1>
+      <Dashboard />
+    </div>
+  );
+}

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+interface Stats {
+  timestamp: number;
+  value: number;
+}
+
+export default function Dashboard() {
+  const [stats, setStats] = useState<Stats>({ timestamp: Date.now(), value: 0 });
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:3001');
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setStats(data);
+      } catch (err) {
+        console.error('Failed to parse message', err);
+      }
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  return (
+    <div>
+      <p>Timestamp: {new Date(stats.timestamp).toLocaleTimeString()}</p>
+      <p>Value: {stats.value.toFixed(2)}</p>
+    </div>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React project with TypeScript
- add WebSocket server example
- document setup instructions

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6862a9dc88e48325a46078da3d0cd8af