### PR TITLE
Add mock train delay chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import TrainDelayChart from './TrainDelayChart';
 
 interface Stats {
   timestamp: number;
@@ -29,6 +30,7 @@ export default function Dashboard() {
     <div>
       <p>Timestamp: {new Date(stats.timestamp).toLocaleTimeString()}</p>
       <p>Value: {stats.value.toFixed(2)}</p>
+      <TrainDelayChart />
     </div>
   );
 }

--- a/src/TrainDelayChart.tsx
+++ b/src/TrainDelayChart.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { trainDelayData } from './mockTrainDelay';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+export default function TrainDelayChart() {
+  const labels = trainDelayData.map((d) => `${d.hour}:00`);
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: 'Totale vertraging (minuten)',
+        data: trainDelayData.map((d) => d.totalDelay),
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+      },
+      title: {
+        display: true,
+        text: 'Totale vertraging per uur',
+      },
+    },
+  };
+
+  return <Bar options={options} data={data} />;
+}

--- a/src/mockTrainDelay.ts
+++ b/src/mockTrainDelay.ts
@@ -1,0 +1,32 @@
+export interface TrainDelay {
+  hour: number;
+  totalDelay: number; // in minutes
+}
+
+// Mock data representing total delay per hour for today
+export const trainDelayData: TrainDelay[] = [
+  { hour: 0, totalDelay: 2 },
+  { hour: 1, totalDelay: 5 },
+  { hour: 2, totalDelay: 0 },
+  { hour: 3, totalDelay: 1 },
+  { hour: 4, totalDelay: 0 },
+  { hour: 5, totalDelay: 3 },
+  { hour: 6, totalDelay: 8 },
+  { hour: 7, totalDelay: 15 },
+  { hour: 8, totalDelay: 12 },
+  { hour: 9, totalDelay: 7 },
+  { hour: 10, totalDelay: 6 },
+  { hour: 11, totalDelay: 4 },
+  { hour: 12, totalDelay: 9 },
+  { hour: 13, totalDelay: 5 },
+  { hour: 14, totalDelay: 11 },
+  { hour: 15, totalDelay: 8 },
+  { hour: 16, totalDelay: 14 },
+  { hour: 17, totalDelay: 20 },
+  { hour: 18, totalDelay: 18 },
+  { hour: 19, totalDelay: 10 },
+  { hour: 20, totalDelay: 6 },
+  { hour: 21, totalDelay: 4 },
+  { hour: 22, totalDelay: 3 },
+  { hour: 23, totalDelay: 1 }
+];


### PR DESCRIPTION
## Summary
- display a bar chart of hourly train delays on the dashboard
- provide mock data for total delay per hour
- add Chart.js and react-chartjs-2 dependencies

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862abf7a7c48325912da8bba87bef31