### PR TITLE
Add live train map

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a simple React + TypeScript project that renders a dashboard with real-time statistics. The dashboard connects to a small WebSocket server which continuously broadcasts random data.
 
+The app now also shows a map with real-time train positions in the Netherlands. Train locations are fetched directly from the [OVapi GTFS realtime feed](https://gtfs.ovapi.nl/nl/).
+
 ## Getting started
 
 1. Install dependencies (requires Node.js installed locally):

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
-    "chart.js": "^4.4.0"
+    "chart.js": "^4.4.0",
+    "react-leaflet": "^4.2.1",
+    "leaflet": "^1.9.4",
+    "gtfs-realtime-bindings": "^3.0.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",
@@ -21,6 +24,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "ts-node": "^10.9.1",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "@types/leaflet": "^1.9.4"
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,5 @@
 import { WebSocketServer } from 'ws';
 import http from 'http';
-
 const server = http.createServer();
 const wss = new WebSocketServer({ server });
 

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import TrainDelayChart from './TrainDelayChart';
+import TrainMap from './TrainMap';
 
 interface Stats {
   timestamp: number;
@@ -31,6 +32,7 @@ export default function Dashboard() {
       <p>Timestamp: {new Date(stats.timestamp).toLocaleTimeString()}</p>
       <p>Value: {stats.value.toFixed(2)}</p>
       <TrainDelayChart />
+      <TrainMap />
     </div>
   );
 }

--- a/src/TrainMap.tsx
+++ b/src/TrainMap.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import * as gtfs from 'gtfs-realtime-bindings';
+
+interface TrainPosition {
+  id: string;
+  lat: number;
+  lon: number;
+  routeId?: string;
+}
+
+export default function TrainMap() {
+  const [positions, setPositions] = useState<TrainPosition[]>([]);
+
+  const fetchPositions = async () => {
+    try {
+      const res = await fetch('https://gtfs.ovapi.nl/nl/vehiclePositions.pb');
+      if (!res.ok) return;
+      const buffer = new Uint8Array(await res.arrayBuffer());
+      const feed = gtfs.transit_realtime.FeedMessage.decode(buffer);
+      const data = feed.entity
+        .filter((e) => e.vehicle && e.vehicle.position)
+        .map((e) => ({
+          id: e.id || '',
+          lat: e.vehicle!.position!.latitude!,
+          lon: e.vehicle!.position!.longitude!,
+          routeId: e.vehicle!.trip?.routeId,
+        }));
+      setPositions(data);
+    } catch (err) {
+      console.error('Failed to fetch train positions', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchPositions();
+    const id = setInterval(fetchPositions, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <MapContainer center={[52.1, 5.1]} zoom={7} style={{ height: '500px', width: '100%' }}>
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
+      {positions.map((p) => (
+        <Marker key={p.id} position={[p.lat, p.lon]}>
+          <Popup>{p.routeId ? `Route ${p.routeId}` : 'Unknown train'}</Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate `react-leaflet` and `gtfs-realtime-bindings`
- fetch realtime train positions on the client instead of the server
- simplify the server back to only broadcasting websocket stats
- update documentation for new map feature

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862c0179c4483259b97b7d98e09b0dd