### PR TITLE
Update artifact step to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,9 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: ./dist
 
   deploy:


### PR DESCRIPTION
## Summary
- switch to `actions/upload-artifact@v4` in the GitHub Pages workflow

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c47c01208325859c60fd2ee6334c