### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,8 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-pages-artifact@v2
         with:
-          name: github-pages
           path: ./dist
 
   deploy:


### PR DESCRIPTION
## Summary
- adjust GitHub Pages workflow to use `actions/upload-pages-artifact`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d7815e54832596f06e47a62fe6c0