### PR TITLE
Fix workflow deprecation and run on PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -25,7 +27,7 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 


### PR DESCRIPTION
## Summary
- enable GitHub Actions workflow on pull_request events
- upgrade upload-pages-artifact step to v3 for Node20 compatibility

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d8855d1c832598d6cb78b42fc859