### PR TITLE
Fix base path config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // When deploying to a subpath like /codex-test, configure the base URL
+  base: '/codex-test/',
 });


### PR DESCRIPTION
## Summary
- configure Vite base path to use `/codex-test/`
- skip Pages deploy in PR workflows

## Testing
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862db91f5088325b5d5a05587ccedcb