### PR TITLE
Rewrite new page layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "chart.js": "^4.4.0",
     "react-leaflet": "^4.2.1",
     "leaflet": "^1.9.4",
-    "gtfs-realtime-bindings": "1.1.0"
+    "gtfs-realtime-bindings": "1.1.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './Dashboard';
+import NewPage from './pages/NewPage';
 
 export default function App() {
   return (
-    <div>
-      <h1>Real-Time Dashboard</h1>
-      <Dashboard />
-    </div>
+    <BrowserRouter>
+      <nav style={{ padding: '1rem', background: '#282c34' }}>
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/">
+          Dashboard
+        </Link>
+        <Link style={{ color: '#fff' }} to="/new">
+          New Page
+        </Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/new" element={<NewPage />} />
+      </Routes>
+    </BrowserRouter>
   );
 }

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -29,6 +29,7 @@ export default function Dashboard() {
 
   return (
     <div>
+      <h1>Real-Time Dashboard</h1>
       <p>Timestamp: {new Date(stats.timestamp).toLocaleTimeString()}</p>
       <p>Value: {stats.value.toFixed(2)}</p>
       <TrainDelayChart />

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/pages/NewPage.css
+++ b/src/pages/NewPage.css
@@ -1,0 +1,116 @@
+.spotify-dashboard {
+  background: #121212;
+  color: #fff;
+  min-height: 100vh;
+  font-family: Arial, sans-serif;
+}
+
+.main-nav {
+  display: flex;
+  align-items: center;
+  padding: 0 1.5rem;
+  background: #000;
+  height: 50px;
+}
+
+.main-nav .logo {
+  margin-right: 2rem;
+  font-weight: bold;
+  color: #1db954;
+}
+
+.main-nav ul {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.main-nav li {
+  margin-right: 1.5rem;
+  cursor: pointer;
+}
+
+.main-nav .active {
+  color: #1db954;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 2rem 1.5rem;
+  border-bottom: 1px solid #333;
+}
+
+.app-info h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.8rem;
+}
+
+.app-info p {
+  margin: 0.2rem 0;
+}
+
+.show-secret {
+  color: #1db954;
+  cursor: pointer;
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+.actions button {
+  margin-left: 1rem;
+  padding: 0.5rem 1rem;
+  font-weight: bold;
+}
+
+.btn-primary {
+  background: #1db954;
+  border: none;
+  color: #fff;
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+}
+
+.grid {
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 300px;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #181818;
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.requests {
+  grid-column: span 2;
+}
+
+.users-box {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.users-box .count {
+  font-size: 3rem;
+  color: #1db954;
+}
+
+.users-box .caption {
+  font-size: 0.9rem;
+}
+
+.map {
+  grid-column: 3;
+  grid-row: 2;
+}

--- a/src/pages/NewPage.tsx
+++ b/src/pages/NewPage.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { MapContainer, TileLayer, CircleMarker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import './NewPage.css';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+export default function NewPage() {
+  const dailyData = {
+    labels: ['08-18', '08-19', '08-20', '08-21', '08-22', '08-23', '08-24'],
+    datasets: [
+      {
+        label: 'Users',
+        data: [1, 2, 3, 2, 4, 1, 3],
+        borderColor: '#1db954',
+        backgroundColor: 'transparent',
+      },
+    ],
+  };
+
+  const monthlyData = {
+    labels: ['05', '06', '07', '08', '09'],
+    datasets: [
+      {
+        label: 'Users',
+        data: [1, 3, 5, 7, 11],
+        borderColor: '#e91429',
+        backgroundColor: 'transparent',
+      },
+    ],
+  };
+
+  const requestData = {
+    labels: ['08-05', '08-10', '08-15', '08-20', '08-25', '09-01', '09-03'],
+    datasets: [
+      {
+        label: '/v1/search',
+        data: [20, 30, 15, 90, 70, 60, 100],
+        borderColor: '#e91429',
+        backgroundColor: 'transparent',
+      },
+      {
+        label: '/v1/me/playlists',
+        data: [5, 10, 5, 30, 40, 20, 50],
+        borderColor: '#1db954',
+        backgroundColor: 'transparent',
+      },
+    ],
+  };
+
+  const mapPositions: [number, number][] = [
+    [52, 5],
+    [48, 15],
+    [40, -3],
+  ];
+
+  return (
+    <div className="spotify-dashboard">
+      <nav className="main-nav">
+        <span className="logo">Spotify for Developers</span>
+        <ul>
+          <li>DISCOVER</li>
+          <li>DOCS</li>
+          <li>CONSOLE</li>
+          <li>COMMUNITY</li>
+          <li className="active">DASHBOARD</li>
+          <li>USE CASES</li>
+        </ul>
+      </nav>
+      <header className="app-header">
+        <div className="app-info">
+          <h1>spotify_themes</h1>
+          <p>A web service playing songs based on themes submitted to the Spotify API.</p>
+          <p>Client ID: abc123••••</p>
+          <a className="show-secret" href="#">Show client secret</a>
+        </div>
+        <div className="actions">
+          <button className="btn-primary">EDIT SETTINGS</button>
+          <button className="btn-outline">LOGOUT</button>
+        </div>
+      </header>
+      <section className="grid">
+        <div className="panel">
+          <Line
+            options={{
+              responsive: true,
+              plugins: { title: { display: true, text: 'Daily Active Users' }, legend: { display: false } },
+            }}
+            data={dailyData}
+          />
+        </div>
+        <div className="panel">
+          <Line
+            options={{
+              responsive: true,
+              plugins: { title: { display: true, text: 'Monthly Active Users' }, legend: { display: false } },
+            }}
+            data={monthlyData}
+          />
+        </div>
+        <div className="panel users-box">
+          <div className="count">11</div>
+          <div className="caption">11 users</div>
+        </div>
+        <div className="panel requests">
+          <Line
+            options={{
+              responsive: true,
+              plugins: { title: { display: true, text: 'Number of Requests/Endpoint' } },
+            }}
+            data={requestData}
+          />
+        </div>
+        <div className="panel map">
+          <MapContainer center={[20, 0]} zoom={2} scrollWheelZoom={false} style={{ height: '100%', width: '100%' }}>
+            <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
+            {mapPositions.map((p, i) => (
+              <CircleMarker key={i} center={p} radius={5} pathOptions={{ color: '#1db954' }} />
+            ))}
+          </MapContainer>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- overhaul `/new` page to mimic Spotify dashboard
- add charts and map with dark themed layout

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636878f4888325a713e34c0550ae91