### PR TITLE
Add calculator page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './Dashboard';
 import NewPage from './pages/NewPage';
+import CalculatorPage from './pages/CalculatorPage';
 
 export default function App() {
   return (
@@ -10,13 +11,17 @@ export default function App() {
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/">
           Dashboard
         </Link>
-        <Link style={{ color: '#fff' }} to="/new">
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/new">
           New Page
+        </Link>
+        <Link style={{ color: '#fff' }} to="/calc">
+          Calculator
         </Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/new" element={<NewPage />} />
+        <Route path="/calc" element={<CalculatorPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/CalculatorPage.css
+++ b/src/pages/CalculatorPage.css
@@ -1,0 +1,69 @@
+.calculator-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+  color: #000;
+}
+
+.top-section {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.history-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+}
+
+.display {
+  flex: 1;
+  text-align: center;
+  font-size: 2rem;
+}
+
+.history-display {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, 50px);
+  grid-auto-rows: 50px;
+  gap: 0.4rem;
+}
+
+.grid button {
+  font-size: 1rem;
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+  cursor: pointer;
+}
+
+.grid button.active {
+  background: #b0d4ff;
+}
+
+.grid .equals,
+.grid button:nth-child(6n),
+.grid button:nth-child(6n+4) {
+  background: #007bff;
+  color: #fff;
+}
+
+.grid .empty {
+  grid-column: span 5;
+}
+
+.bottom-bar {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: #007bff;
+  cursor: pointer;
+}

--- a/src/pages/CalculatorPage.tsx
+++ b/src/pages/CalculatorPage.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import './CalculatorPage.css';
+
+function factorial(n: number): number {
+  if (n < 0) return NaN;
+  let res = 1;
+  for (let i = 2; i <= n; i++) res *= i;
+  return res;
+}
+
+export default function CalculatorPage() {
+  const [input, setInput] = useState('');
+  const [ans, setAns] = useState(0);
+  const [angleMode, setAngleMode] = useState<'DEG' | 'RAD'>('DEG');
+  const append = (value: string) => setInput((prev) => prev + value);
+
+  const evaluate = () => {
+    try {
+      const replaced = input
+        .replace(/π/g, 'Math.PI')
+        .replace(/e/g, 'Math.E')
+        .replace(/Ans/g, ans.toString())
+        .replace(/sin\(/g, `Math.sin(`)
+        .replace(/cos\(/g, `Math.cos(`)
+        .replace(/tan\(/g, `Math.tan(`);
+      const expr = angleMode === 'DEG'
+        ? replaced.replace(/Math\.sin\(([^)]+)\)/g, (_, x) => `Math.sin((${x})*Math.PI/180)`)
+            .replace(/Math\.cos\(([^)]+)\)/g, (_, x) => `Math.cos((${x})*Math.PI/180)`)
+            .replace(/Math\.tan\(([^)]+)\)/g, (_, x) => `Math.tan((${x})*Math.PI/180)`)
+        : replaced;
+      // handle factorial
+      const factExpr = expr.replace(/(\d+)!/g, (_, n) => `factorial(${n})`);
+      // eslint-disable-next-line no-new-func
+      const result = Function('factorial', `return ${factExpr}`)(factorial);
+      setAns(result);
+      setInput('');
+    } catch {
+      setInput('');
+    }
+  };
+
+  const clearEntry = () => setInput('');
+
+  return (
+    <div className="calculator-page">
+      <div className="top-section">
+        <button className="history-btn">⏰</button>
+        <div className="history-display">Ans = {ans.toFixed(5)}</div>
+        <div className="display">{input || '0'}</div>
+      </div>
+      <div className="grid">
+        <button className={angleMode === 'RAD' ? 'active' : ''} onClick={() => setAngleMode('RAD')}>Rad</button>
+        <button onClick={() => append('(')}>(</button>
+        <button onClick={() => append(')')}>)</button>
+        <button onClick={() => append('!')}>x!</button>
+        <button onClick={() => append('**')}>**</button>
+        <button className={angleMode === 'DEG' ? 'active' : ''} onClick={() => setAngleMode('DEG')}>Deg</button>
+
+        <button onClick={() => append('Inv')}>Inv</button>
+        <button onClick={() => append('sin(')}>sin</button>
+        <button onClick={() => append('7')}>7</button>
+        <button onClick={() => append('8')}>8</button>
+        <button onClick={() => append('9')}>9</button>
+        <button onClick={() => append('%')}>%</button>
+        <button onClick={clearEntry}>CE</button>
+
+        <button onClick={() => append('π')}>π</button>
+        <button onClick={() => append('cos(')}>cos</button>
+        <button onClick={() => append('4')}>4</button>
+        <button onClick={() => append('5')}>5</button>
+        <button onClick={() => append('6')}>6</button>
+        <button onClick={() => append('/')}>÷</button>
+
+        <button onClick={() => append('e')}>e</button>
+        <button onClick={() => append('tan(')}>tan</button>
+        <button onClick={() => append('1')}>1</button>
+        <button onClick={() => append('2')}>2</button>
+        <button onClick={() => append('3')}>3</button>
+        <button onClick={() => append('*')}>×</button>
+
+        <button onClick={() => append('Ans')}>Ans</button>
+        <button onClick={() => append('e')}>EXP</button>
+        <button onClick={() => append('0')}>0</button>
+        <button onClick={() => append('.')}>.</button>
+        <button className="equals" onClick={evaluate}>=</button>
+        <button onClick={() => append('-')}>−</button>
+
+        <div className="empty" />
+        <button onClick={() => append('+')}>+</button>
+      </div>
+      <div className="bottom-bar">Maths solver &gt;</div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add router link and route for `/calc`
- implement `CalculatorPage` with a simple scientific calculator layout
- style calculator with a grid layout
- ignore `node_modules` and `dist` output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68638d30c9088325bb2279f95819d691