### PR TITLE
Add PRL page with moving trains

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import Dashboard from './Dashboard';
 import NewPage from './pages/NewPage';
 import CalculatorPage from './pages/CalculatorPage';
+import PRLPage from './pages/PRLPage';
 
 export default function App() {
   return (
@@ -14,6 +15,9 @@ export default function App() {
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/new">
           New Page
         </Link>
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/prl">
+          PRL
+        </Link>
         <Link style={{ color: '#fff' }} to="/calc">
           Calculator
         </Link>
@@ -21,6 +25,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/new" element={<NewPage />} />
+        <Route path="/prl" element={<PRLPage />} />
         <Route path="/calc" element={<CalculatorPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/PRLPage.css
+++ b/src/pages/PRLPage.css
@@ -1,0 +1,8 @@
+.prl-page {
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}
+
+.prl-page h1 {
+  margin-bottom: 1rem;
+}

--- a/src/pages/PRLPage.css
+++ b/src/pages/PRLPage.css
@@ -6,3 +6,20 @@
 .prl-page h1 {
   margin-bottom: 1rem;
 }
+
+.schedule-table {
+  margin-top: 1rem;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.schedule-table th,
+.schedule-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.schedule-table th {
+  background: #f2f2f2;
+}

--- a/src/pages/PRLPage.tsx
+++ b/src/pages/PRLPage.tsx
@@ -3,25 +3,62 @@ import { MapContainer, TileLayer, Marker } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import './PRLPage.css';
 
+interface Schedule {
+  origin: string;
+  destination: string;
+  departure: string;
+  arrival: string;
+}
+
 interface Train {
   id: number;
   lat: number;
   lon: number;
   dx: number;
   dy: number;
+  schedule: Schedule;
 }
 
 export default function PRLPage() {
   const [trains, setTrains] = useState<Train[]>([]);
 
   useEffect(() => {
-    const initTrains: Train[] = Array.from({ length: 10 }, (_, i) => ({
-      id: i,
-      lat: 52 + Math.random(),
-      lon: 4 + Math.random() * 3,
-      dx: (Math.random() - 0.5) * 0.02,
-      dy: (Math.random() - 0.5) * 0.02,
-    }));
+    const stations = [
+      'Amsterdam',
+      'Utrecht',
+      'Rotterdam',
+      'Den Haag',
+      'Eindhoven',
+      'Groningen',
+      'Arnhem',
+    ];
+    const pad = (n: number) => n.toString().padStart(2, '0');
+
+    const initTrains: Train[] = Array.from({ length: 10 }, (_, i) => {
+      const origin = stations[Math.floor(Math.random() * stations.length)];
+      let destination = origin;
+      while (destination === origin) {
+        destination = stations[Math.floor(Math.random() * stations.length)];
+      }
+      const now = new Date();
+      const dep = new Date(now.getTime() + Math.random() * 3600000);
+      const arr = new Date(dep.getTime() + (30 + Math.random() * 60) * 60000);
+      const time = (d: Date) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+      return {
+        id: i,
+        lat: 52 + Math.random(),
+        lon: 4 + Math.random() * 3,
+        dx: (Math.random() - 0.5) * 0.02,
+        dy: (Math.random() - 0.5) * 0.02,
+        schedule: {
+          origin,
+          destination,
+          departure: time(dep),
+          arrival: time(arr),
+        },
+      };
+    });
     setTrains(initTrains);
   }, []);
 
@@ -54,6 +91,27 @@ export default function PRLPage() {
           <Marker key={t.id} position={[t.lat, t.lon]} />
         ))}
       </MapContainer>
+
+      <table className="schedule-table">
+        <thead>
+          <tr>
+            <th>Trein</th>
+            <th>Vertrek</th>
+            <th>Aankomst</th>
+          </tr>
+        </thead>
+        <tbody>
+          {trains.map((t) => (
+            <tr key={t.id}>
+              <td>
+                {t.schedule.origin} → {t.schedule.destination}
+              </td>
+              <td>{t.schedule.departure}</td>
+              <td>{t.schedule.arrival}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/pages/PRLPage.tsx
+++ b/src/pages/PRLPage.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { MapContainer, TileLayer, Marker } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import './PRLPage.css';
+
+interface Train {
+  id: number;
+  lat: number;
+  lon: number;
+  dx: number;
+  dy: number;
+}
+
+export default function PRLPage() {
+  const [trains, setTrains] = useState<Train[]>([]);
+
+  useEffect(() => {
+    const initTrains: Train[] = Array.from({ length: 10 }, (_, i) => ({
+      id: i,
+      lat: 52 + Math.random(),
+      lon: 4 + Math.random() * 3,
+      dx: (Math.random() - 0.5) * 0.02,
+      dy: (Math.random() - 0.5) * 0.02,
+    }));
+    setTrains(initTrains);
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTrains((prev) =>
+        prev.map((t) => {
+          let lat = t.lat + t.dy;
+          let lon = t.lon + t.dx;
+          if (lat > 53) lat = 51;
+          if (lat < 51) lat = 53;
+          if (lon > 7.2) lon = 3.2;
+          if (lon < 3.2) lon = 7.2;
+          return { ...t, lat, lon };
+        })
+      );
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="prl-page">
+      <h1>ProRail Procesleiding (PRL)</h1>
+      <MapContainer center={[52.2, 5.2]} zoom={7} style={{ height: '500px', width: '100%' }}>
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution="&copy; OpenStreetMap contributors"
+        />
+        {trains.map((t) => (
+          <Marker key={t.id} position={[t.lat, t.lon]} />
+        ))}
+      </MapContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PRL (Procesleiding) page with animated train markers
- style the PRL page
- wire new route and nav link

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864e789b4f08325a9b51b0f6bdd4b38