### PR TITLE
Add PRL control screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import PRLControlPage from './pages/PRLControlPage';
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <nav style={{ padding: '1rem', background: '#282c34' }}>
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/">
           Dashboard

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from './Dashboard';
 import NewPage from './pages/NewPage';
 import CalculatorPage from './pages/CalculatorPage';
 import PRLPage from './pages/PRLPage';
+import PRLControlPage from './pages/PRLControlPage';
 
 export default function App() {
   return (
@@ -16,7 +17,10 @@ export default function App() {
           New Page
         </Link>
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/prl">
-          PRL
+          PRL Map
+        </Link>
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/prl-control">
+          PRL Control
         </Link>
         <Link style={{ color: '#fff' }} to="/calc">
           Calculator
@@ -26,6 +30,7 @@ export default function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/new" element={<NewPage />} />
         <Route path="/prl" element={<PRLPage />} />
+        <Route path="/prl-control" element={<PRLControlPage />} />
         <Route path="/calc" element={<CalculatorPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/PRLControlPage.css
+++ b/src/pages/PRLControlPage.css
@@ -1,0 +1,39 @@
+.prl-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas:
+    "bp1 bp2 sidebar"
+    "proc storingen sidebar";
+  gap: 0.5rem;
+  height: calc(100vh - 60px);
+  background: #000;
+  color: #fff;
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+#bp1 { grid-area: bp1; }
+#bp2 { grid-area: bp2; }
+.procesplan { grid-area: proc; overflow:auto; }
+.storingen { grid-area: storingen; overflow:auto; }
+.sidebar { grid-area: sidebar; display:flex; flex-direction:column; gap:0.5rem; }
+
+.baanplan svg { width: 100%; height: 100%; background:#000; }
+.baanplan path { stroke:#fff; stroke-width:1; fill:none; }
+.baanplan path.route { stroke:#00ff00; }
+.baanplan path.released { stroke:#00ffff; }
+.baanplan path.occupied { stroke:#ffff00; }
+.baanplan path.fault { stroke:#ff0000; }
+.signal { fill:#fff; cursor:pointer; }
+
+.procesplan table { width:100%; border-collapse: collapse; color:#000; }
+.procesplan th, .procesplan td { border:1px solid #ddd; padding:0.25rem; }
+.procesplan th { background:#f2f2f2; }
+.procesplan tr.actief { background:#0f0; }
+
+.storingen ul { list-style:none; padding-left:0; color:#fff; }
+.storingen li { margin-bottom:0.25rem; }
+
+.sidebar button { padding:0.5rem; background:#333; color:#fff; border:none; cursor:pointer; }
+

--- a/src/pages/PRLControlPage.tsx
+++ b/src/pages/PRLControlPage.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import './PRLControlPage.css';
+
+interface Segment {
+  id: string;
+  path: string;
+  state: 'default' | 'occupied' | 'route' | 'released' | 'fault';
+}
+
+interface Signal {
+  id: string;
+  x: number;
+  y: number;
+}
+
+const initialSegments: Segment[] = [
+  { id: 's1', path: 'M10 50 L90 50', state: 'default' },
+  { id: 's2', path: 'M90 50 L170 50', state: 'default' },
+  { id: 's3', path: 'M90 50 L90 90', state: 'default' },
+];
+
+const signals: Signal[] = [
+  { id: 'A', x: 10, y: 50 },
+  { id: 'B', x: 170, y: 50 },
+  { id: 'C', x: 90, y: 90 },
+];
+
+export default function PRLControlPage() {
+  const [segments, setSegments] = useState(initialSegments);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const setRoute = (start: string, end: string) => {
+    let routeSegs: string[] = [];
+    if (start === 'A' && end === 'B') routeSegs = ['s1', 's2'];
+    else if (start === 'A' && end === 'C') routeSegs = ['s1', 's3'];
+    else {
+      setMessages(m => [`Ongeldige rijweg ${start}→${end}`, ...m]);
+      return;
+    }
+
+    const blocked = routeSegs.some(id => segments.find(s => s.id === id)?.state !== 'default');
+    if (blocked) {
+      setMessages(m => [`Rijweg geblokkeerd ${start}→${end}`, ...m]);
+      return;
+    }
+
+    setSegments(segs => segs.map(s => routeSegs.includes(s.id) ? { ...s, state: 'route' } : s));
+    setMessages(m => [`Rijweg ingesteld ${start}→${end}`, ...m]);
+  };
+
+  const handleSignalClick = (id: string) => {
+    if (!selected) {
+      setSelected(id);
+    } else {
+      setRoute(selected, id);
+      setSelected(null);
+    }
+  };
+
+  return (
+    <div className="prl-grid">
+      <div className="baanplan" id="bp1">
+        <svg viewBox="0 0 180 100">
+          {segments.map(s => (
+            <path key={s.id} d={s.path} className={s.state} />
+          ))}
+          {signals.map(sig => (
+            <rect
+              key={sig.id}
+              x={sig.x - 3}
+              y={sig.y - 3}
+              width={6}
+              height={6}
+              className="signal"
+              onClick={() => handleSignalClick(sig.id)}
+            />
+          ))}
+        </svg>
+      </div>
+      <div className="baanplan" id="bp2">
+        <svg viewBox="0 0 180 100">
+          <text x="10" y="20" fill="white">Bedienscherm 2</text>
+        </svg>
+      </div>
+      <div className="procesplan">
+        <table>
+          <thead>
+            <tr>
+              <th>Trein</th>
+              <th>Vertrekspoor</th>
+              <th>Aankomst</th>
+              <th>Vertrektijd</th>
+              <th>Rijweg?</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="actief">
+              <td>4532</td>
+              <td>14a</td>
+              <td>15b</td>
+              <td>12:47</td>
+              <td>✅</td>
+            </tr>
+            <tr>
+              <td>6621</td>
+              <td>5</td>
+              <td>7</td>
+              <td>13:05</td>
+              <td>❌</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div className="storingen">
+        <ul>
+          {messages.map((m,i) => <li key={i}>{m}</li>)}
+        </ul>
+      </div>
+      <div className="sidebar">
+        <button>📞 Bel trein 4532</button>
+        <button>📻 Omroep</button>
+        <button>📁 Logboek</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new PRL control screen with simple route setting logic
- style the new page using grid layout
- link the new control page from the app navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864f47620348325931caa3873bf1fbe