### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ npm run dev
 Navigate to `http://localhost:5173` (default Vite port) to see the dashboard updating in real time.
 
 The WebSocket server runs on `ws://localhost:3001` and sends a new random value every second.
+
+## GitHub Pages
+
+When deploying to GitHub Pages the application is served from the `/codex-test/` subpath. The build pipeline copies `index.html` to `404.html` so that unmatched paths load the React application without a redirect.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "postbuild": "cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "server": "ts-node server/index.ts"
   },


### PR DESCRIPTION
## Summary
- copy `index.html` to `404.html` during `npm run build`
- clarify in README that the build pipeline generates the 404 page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686513f018d48325a84799e3a68e94ae