### PR TITLE
Add Green Screen page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tensorflow-models/blazeface": "^0.1.0",
+        "@tensorflow-models/body-pix": "^2.2.1",
         "@tensorflow/tfjs": "^4.9.0",
         "chart.js": "^4.4.0",
         "gtfs-realtime-bindings": "1.1.0",
@@ -17,7 +18,8 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^6.22.0"
+        "react-router-dom": "^6.22.0",
+        "three": "^0.178.0"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.4",
@@ -1171,6 +1173,17 @@
       "integrity": "sha512-Qc5Wii8/OE5beC7XfehkhF9SEFLaPbVKnxxalV0T9JXsUynXqvLommc9Eko7b8zXKy4SJ1BtVlcX2cmCzQrn9A==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@tensorflow/tfjs-converter": "^4.10.0",
+        "@tensorflow/tfjs-core": "^4.10.0"
+      }
+    },
+    "node_modules/@tensorflow-models/body-pix": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/body-pix/-/body-pix-2.2.1.tgz",
+      "integrity": "sha512-JeZHcpVMR0mW2znmF0FpZ0f7zpSY7c6+A7FBOmcIyZupTkXmG3MwGGqFPsVjRBwfqaKa4qYCJd7Svqo6rMzJYw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@tensorflow/tfjs-backend-webgl": "^4.10.0",
         "@tensorflow/tfjs-converter": "^4.10.0",
         "@tensorflow/tfjs-core": "^4.10.0"
       }
@@ -3035,6 +3048,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "server": "ts-node server/index.ts"
   },
   "dependencies": {
+    "@tensorflow-models/blazeface": "^0.1.0",
+    "@tensorflow-models/body-pix": "^2.2.1",
+    "@tensorflow/tfjs": "^4.9.0",
     "chart.js": "^4.4.0",
     "gtfs-realtime-bindings": "1.1.0",
     "leaflet": "^1.9.4",
@@ -17,11 +20,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "leaflet": "^1.9.4",
-    "gtfs-realtime-bindings": "1.1.0",
     "react-router-dom": "^6.22.0",
-    "@tensorflow/tfjs": "^4.9.0",
-    "@tensorflow-models/blazeface": "^0.1.0",
     "three": "^0.178.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import PRLPage from './pages/PRLPage';
 import PRLControlPage from './pages/PRLControlPage';
 import RouteLintPage from './pages/RouteLintPage';
 import WebcamPage from './pages/WebcamPage';
+import GreenScreenPage from './pages/GreenScreenPage';
 import VPTPage from './pages/VPTPage';
 import TrainCabPage from './pages/TrainCabPage';
 
@@ -32,6 +33,9 @@ export default function App() {
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/webcam">
           Webcam
         </Link>
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/green">
+          Green Screen
+        </Link>
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/vpt">
           VPT Sim
         </Link>
@@ -49,6 +53,7 @@ export default function App() {
         <Route path="/prl-control" element={<PRLControlPage />} />
         <Route path="/routelint" element={<RouteLintPage />} />
         <Route path="/webcam" element={<WebcamPage />} />
+        <Route path="/green" element={<GreenScreenPage />} />
         <Route path="/vpt" element={<VPTPage />} />
         <Route path="/cab" element={<TrainCabPage />} />
         <Route path="/calc" element={<CalculatorPage />} />

--- a/src/pages/GreenScreenPage.css
+++ b/src/pages/GreenScreenPage.css
@@ -1,0 +1,21 @@
+.green-screen-page {
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}
+
+.gs-container {
+  position: relative;
+  display: inline-block;
+}
+
+.hidden-video {
+  display: none;
+}
+
+.gs-canvas {
+  width: 100%;
+  max-width: 640px;
+  border-radius: 4px;
+}

--- a/src/pages/GreenScreenPage.tsx
+++ b/src/pages/GreenScreenPage.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from 'react';
+import * as bodyPix from '@tensorflow-models/body-pix';
+import '@tensorflow/tfjs';
+import './GreenScreenPage.css';
+
+export default function GreenScreenPage() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    navigator.mediaDevices
+      .getUserMedia({ video: true })
+      .then((stream) => {
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          videoRef.current.play();
+        }
+      })
+      .catch(() => {
+        // ignore
+      });
+  }, []);
+
+  useEffect(() => {
+    let animationId: number;
+    let model: bodyPix.BodyPix | null = null;
+
+    const process = async () => {
+      if (!model || !videoRef.current || !canvasRef.current) {
+        animationId = requestAnimationFrame(process);
+        return;
+      }
+      const ctx = canvasRef.current.getContext('2d');
+      if (!ctx) {
+        animationId = requestAnimationFrame(process);
+        return;
+      }
+      const segmentation = await model.segmentPerson(videoRef.current);
+      const mask = bodyPix.toMask(segmentation, { r: 255, g: 255, b: 255, a: 0 }, { r: 0, g: 255, b: 0, a: 255 });
+      bodyPix.drawMask(canvasRef.current, videoRef.current, mask, 1, 0, false);
+      animationId = requestAnimationFrame(process);
+    };
+
+    bodyPix.load().then((loaded) => {
+      model = loaded;
+      process();
+    });
+
+    return () => cancelAnimationFrame(animationId);
+  }, []);
+
+  return (
+    <div className="green-screen-page">
+      <div className="gs-container">
+        <video ref={videoRef} className="hidden-video" playsInline />
+        <canvas ref={canvasRef} className="gs-canvas" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new GreenScreenPage that uses BodyPix to replace the webcam background
- register route and navigation link
- install body-pix dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68667239aefc8325a8fe3fc5dc3622d6