### PR TITLE
Add receipt OCR page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.22.0",
+        "tesseract.js": "^6.0.1",
         "three": "^0.178.0"
       },
       "devDependencies": {
@@ -1604,6 +1605,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT"
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2274,6 +2281,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2299,6 +2312,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2622,6 +2641,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -3049,6 +3077,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-6.0.1.tgz",
+      "integrity": "sha512-/sPvMvrCtgxnNRCjbTYbr7BRu0yfWDsMZQ2a/T5aN/L1t8wUQN6tTWv6p6FwzpoEBA0jrN2UD2SX4QQFRdoDbA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^6.0.0",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-6.0.0.tgz",
+      "integrity": "sha512-1Qncm/9oKM7xgrQXZXNB+NRh19qiXGhxlrR8EwFbK5SaUbPZnS5OMtP/ghtqfd23hsr1ZvZbZjeuAGcMxd/ooA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/three": {
       "version": "0.178.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
@@ -3268,6 +3320,12 @@
         }
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3395,6 +3453,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.22.0",
+    "tesseract.js": "^6.0.1",
     "three": "^0.178.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import WebcamPage from './pages/WebcamPage';
 import GreenScreenPage from './pages/GreenScreenPage';
 import VPTPage from './pages/VPTPage';
 import TrainCabPage from './pages/TrainCabPage';
+import ReceiptPage from './pages/ReceiptPage';
 
 export default function App() {
   return (
@@ -42,6 +43,9 @@ export default function App() {
         <Link style={{ color: '#fff', marginRight: '1rem' }} to="/cab">
           Cab View
         </Link>
+        <Link style={{ color: '#fff', marginRight: '1rem' }} to="/receipt">
+          Receipt OCR
+        </Link>
         <Link style={{ color: '#fff' }} to="/calc">
           Calculator
         </Link>
@@ -56,6 +60,7 @@ export default function App() {
         <Route path="/green" element={<GreenScreenPage />} />
         <Route path="/vpt" element={<VPTPage />} />
         <Route path="/cab" element={<TrainCabPage />} />
+        <Route path="/receipt" element={<ReceiptPage />} />
         <Route path="/calc" element={<CalculatorPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/ReceiptPage.css
+++ b/src/pages/ReceiptPage.css
@@ -1,0 +1,39 @@
+.receipt-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  font-family: Arial, sans-serif;
+}
+
+.processing {
+  margin-top: 1rem;
+}
+
+.results {
+  width: 100%;
+  max-width: 400px;
+  margin-top: 1rem;
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.item-name {
+  margin-left: 0.5rem;
+}
+
+.totals {
+  margin-top: 1rem;
+  text-align: right;
+}

--- a/src/pages/ReceiptPage.tsx
+++ b/src/pages/ReceiptPage.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import Tesseract from 'tesseract.js';
+import './ReceiptPage.css';
+
+interface Item {
+  name: string;
+  price: number;
+}
+
+export default function ReceiptPage() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [subtotal, setSubtotal] = useState<number | null>(null);
+  const [total, setTotal] = useState<number | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) {
+      recognizeImage(file);
+    }
+  };
+
+  const recognizeImage = async (file: File) => {
+    setProcessing(true);
+    try {
+      const {
+        data: { text },
+      } = await Tesseract.recognize(file, 'eng');
+      parseText(text);
+    } catch {
+      // ignore errors
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const parseText = (text: string) => {
+    const lines = text.split(/\r?\n/);
+    const parsed: Item[] = [];
+    let foundSubtotal: number | null = null;
+    let foundTotal: number | null = null;
+
+    for (const line of lines) {
+      const priceMatch = line.match(/(\d+[.,]\d{2})/);
+      if (priceMatch) {
+        const price = parseFloat(priceMatch[1].replace(',', '.'));
+        const lower = line.toLowerCase();
+        if (lower.includes('subtotal')) {
+          foundSubtotal = price;
+        } else if (lower.includes('total')) {
+          foundTotal = price;
+        } else {
+          const name = line.replace(priceMatch[0], '').trim();
+          if (name) {
+            parsed.push({ name, price });
+          }
+        }
+      }
+    }
+    setItems(parsed);
+    const calculatedSubtotal = parsed.reduce((s, i) => s + i.price, 0);
+    setSubtotal(foundSubtotal ?? calculatedSubtotal);
+    setTotal(foundTotal ?? foundSubtotal ?? calculatedSubtotal);
+  };
+
+  return (
+    <div className="receipt-page">
+      <input type="file" accept="image/*" onChange={handleFileChange} />
+      {processing && <div className="processing">Processing...</div>}
+      {items.length > 0 && (
+        <div className="results">
+          <ul className="item-list">
+            {items.map((item, idx) => (
+              <li key={idx} className="item">
+                <label>
+                  <input type="checkbox" />
+                  <span className="item-name">{item.name}</span>
+                </label>
+                <span className="item-price">{item.price.toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="totals">
+            <div className="subtotal">Subtotal: {subtotal?.toFixed(2)}</div>
+            <div className="total">Total: {total?.toFixed(2)}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `tesseract.js` dependency
- create `ReceiptPage` to upload receipt images and run OCR
- style receipt OCR results
- link new page in the navigation and router

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68667722fec0832582f5f189a30894d4